### PR TITLE
Changed -25 Error to return 'missing input' instead of nothing in sendrawtransaction

### DIFF
--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -743,12 +743,17 @@ Value sendrawtransaction(const Array& params, bool fHelp)
     if (!fHaveMempool && !fHaveChain) {
         // push to local node and sync with wallets
         CValidationState state;
-        if (!AcceptToMemoryPool(mempool, state, tx, false, NULL, !fOverrideFees)) {
-            if(state.IsInvalid())
+	bool fMissingInputs;
+        if (!AcceptToMemoryPool(mempool, state, tx, false, &fMissingInputs, !fOverrideFees)) {
+            if(state.IsInvalid()) {
                 throw JSONRPCError(RPC_TRANSACTION_REJECTED, strprintf("%i: %s", state.GetRejectCode(), state.GetRejectReason()));
-            else
-                throw JSONRPCError(RPC_TRANSACTION_ERROR, state.GetRejectReason());
-        }
+	    } else {
+                if (fMissingInputs) {
+		    throw JSONRPCError(RPC_TRANSACTION_ERROR, "Missing inputs");
+		}
+		throw JSONRPCError(RPC_TRANSACTION_ERROR, state.GetRejectReason());
+	    }
+	}
     } else if (fHaveChain) {
         throw JSONRPCError(RPC_TRANSACTION_ALREADY_IN_CHAIN, "transaction already in block chain");
     }


### PR DESCRIPTION
Cf the PR from Sipa : https://github.com/bitcoin/bitcoin/pull/5418